### PR TITLE
Fix auth text boxes not accepting input

### DIFF
--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -52,30 +52,14 @@ export function AuthForm({ onError }: AuthFormProps) {
       }
     }
 
-    const handleMouseDown = (e: Event) => {
-      const target = e.target as HTMLElement
-      const isInteractive = InteractionDetector.isInteractive(target, containerRef)
-      if (isInteractive) {
-        e.stopPropagation()
-      }
-    }
-
-    const handleTouchStart = (e: Event) => {
-      const target = e.target as HTMLElement
-      const isInteractive = InteractionDetector.isInteractive(target, containerRef)
-      if (isInteractive) {
-        e.stopPropagation()
-      }
-    }
+    // Previously this component stopped event propagation on mousedown/touchstart
+    // which prevented inputs from receiving focus. Those handlers have been
+    // removed to allow normal interaction.
 
     container.addEventListener("click", handleClick, { capture: true })
-    container.addEventListener("mousedown", handleMouseDown, { capture: true })
-    container.addEventListener("touchstart", handleTouchStart, { capture: true })
 
     return () => {
       container.removeEventListener("click", handleClick, { capture: true })
-      container.removeEventListener("mousedown", handleMouseDown, { capture: true })
-      container.removeEventListener("touchstart", handleTouchStart, { capture: true })
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- remove mousedown/touchstart suppression in `AuthForm`

The previous event handlers stopped propagation on mousedown and touchstart in the Supabase auth form. Because they ran in the capture phase, clicks on inputs never reached the fields so they couldn't receive focus. With those handlers removed, typing works again.

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_b_6872fa3e86d08326bacf3880b1bc2f17