### PR TITLE
Handle password reset redirect in auth callback

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -9,6 +9,15 @@ export async function GET(request: Request) {
 
   authLogger.log("Auth callback received", { url: request.url, codeExists: !!code })
 
+  // Handle password recovery flow by redirecting to reset password page without auto sign-in
+  const type = searchParams.get("type")
+  if (type === "recovery") {
+    const queryString = searchParams.toString()
+    const redirectUrl = `${origin}/reset-password${queryString ? `?${queryString}` : ""}`
+    authLogger.log("Recovery flow detected, redirecting to reset-password.", { redirectTo: redirectUrl })
+    return NextResponse.redirect(redirectUrl)
+  }
+
   if (code) {
     const supabase = createClient()
     const { error } = await supabase.auth.exchangeCodeForSession(code)


### PR DESCRIPTION
Redirect `type=recovery` auth callback to `/reset-password` to prevent auto-sign-in during password reset flows.

---
<a href="https://cursor.com/background-agent?bcId=bc-a70a9dd3-71f5-44fe-88ad-330616f3812a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a70a9dd3-71f5-44fe-88ad-330616f3812a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

