### PR TITLE
Preserve auth tokens on password reset redirect

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -9,12 +9,12 @@ export async function GET(request: Request) {
 
   authLogger.log("Auth callback received", { url: request.url, codeExists: !!code })
 
-  // Handle password recovery flow by redirecting to reset password page without auto sign-in
+  // Handle password recovery flow by redirecting to reset password page with tokens in URL fragment
   const type = searchParams.get("type")
   if (type === "recovery") {
-    const queryString = searchParams.toString()
-    const redirectUrl = `${origin}/reset-password${queryString ? `?${queryString}` : ""}`
-    authLogger.log("Recovery flow detected, redirecting to reset-password.", { redirectTo: redirectUrl })
+    const fragment = code ? `#access_token=${encodeURIComponent(code)}&type=recovery` : `#type=recovery`
+    const redirectUrl = `${origin}/reset-password${fragment}`
+    authLogger.log("Recovery flow detected, redirecting to reset-password with fragment.", { redirectTo: redirectUrl, codeExists: !!code })
     return NextResponse.redirect(redirectUrl)
   }
 


### PR DESCRIPTION
Preserve authentication tokens during password recovery redirect by passing them in the URL fragment.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b96f10b-a97a-43d9-9b48-b7d9ee39eb0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b96f10b-a97a-43d9-9b48-b7d9ee39eb0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

