### PR TITLE
Improve touch handling for window controls

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
+import "@/styles/mobile-fixes.css"
 import { ThemeProvider } from "next-themes"
 
 const inter = Inter({ subsets: ["latin"] })

--- a/components/auth/auth-error.tsx
+++ b/components/auth/auth-error.tsx
@@ -12,9 +12,28 @@ export function AuthError({ error, onDismiss }: AuthErrorProps) {
         <p className="text-sm flex-1">{error}</p>
         {onDismiss && (
           <button
-            onClick={onDismiss}
-            className="ml-2 text-red-500 hover:text-red-700 text-lg leading-none"
+            onClick={(e) => {
+              e.preventDefault()
+              onDismiss?.()
+            }}
+            onTouchEnd={(e) => {
+              e.preventDefault()
+              onDismiss?.()
+            }}
+            className="ml-2 text-red-500 hover:text-red-700 active:text-red-800 transition-colors duration-150 flex items-center justify-center rounded focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
             aria-label="Dismiss error"
+            style={{
+              minWidth: "var(--touch-target-min, 48px)",
+              minHeight: "var(--touch-target-min, 48px)",
+              touchAction: "manipulation",
+              cursor: "pointer",
+              fontSize: "18px",
+              lineHeight: "1",
+              userSelect: "none",
+              WebkitUserSelect: "none",
+              WebkitTouchCallout: "none",
+            }}
+            data-testid="error-dismiss-button"
           >
             ×
           </button>

--- a/components/window-frame.tsx
+++ b/components/window-frame.tsx
@@ -54,9 +54,25 @@ export function WindowFrame({
     return null
   }
 
-  const handleClose = () => {
+  const handleClose = (e: React.MouseEvent | React.TouchEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
     removeWindow(id)
     vibrate()
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    const touch = e.changedTouches[0]
+    const element = document.elementFromPoint(touch.clientX, touch.clientY)
+    const button = e.currentTarget
+
+    if (element === button || button.contains(element as Node)) {
+      removeWindow(id)
+      vibrate()
+    }
   }
 
   return (
@@ -89,11 +105,28 @@ export function WindowFrame({
           <span className="text-xs sm:text-xs font-mono pointer-events-none truncate flex-1 mr-2">{title}</span>
           <button
             onClick={handleClose}
-            className="p-2 hover:bg-red-600 rounded touch-manipulation flex items-center justify-center w-8 h-8 sm:w-5 sm:h-5 text-xs flex-shrink-0"
+            onTouchEnd={handleTouchEnd}
+            className={cn(
+              "flex items-center justify-center rounded flex-shrink-0",
+              "bg-transparent hover:bg-red-600 active:bg-red-700",
+              "transition-colors duration-150",
+              "focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-black",
+            )}
             aria-label="Close window"
-            style={{ touchAction: "manipulation", cursor: "pointer", minWidth: "44px", minHeight: "44px" }}
+            style={{
+              width: "var(--touch-target-min, 48px)",
+              height: "var(--touch-target-min, 48px)",
+              touchAction: "manipulation",
+              cursor: "pointer",
+              position: "relative",
+              zIndex: 10,
+              userSelect: "none",
+              WebkitUserSelect: "none",
+              WebkitTouchCallout: "none",
+            }}
+            data-testid="window-close-button"
           >
-            <X size={16} />
+            <X size={16} className="pointer-events-none" />
           </button>
         </div>
 

--- a/styles/mobile-fixes.css
+++ b/styles/mobile-fixes.css
@@ -1,0 +1,27 @@
+/* Global definition for touch target size */
+:root {
+  --touch-target-min: 48px;
+}
+
+/* iOS Safari specific fixes */
+@supports (-webkit-touch-callout: none) {
+  body {
+    /* Prevent text selection and callouts globally on touch areas */
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+  }
+}
+
+/* Ensure all buttons have a minimum touch target */
+.window-title-bar button, [data-testid="error-dismiss-button"] {
+  min-width: var(--touch-target-min) !important;
+  min-height: var(--touch-target-min) !important;
+  touch-action: manipulation !important;
+  -webkit-tap-highlight-color: transparent !important;
+  cursor: pointer !important;
+}
+
+/* Prevent icons inside buttons from intercepting touch events */
+.window-title-bar button svg {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
## Summary
- enhance the window frame close button to better support touch interactions and accessibility
- update the auth error dismiss button with touch-friendly handlers and styling
- add global mobile-specific CSS fixes and load them via the root layout

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d69160abb08326a57cb8730f8a918c