### PR TITLE
Improve window controls for mobile and desktop

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -53,6 +53,90 @@
     --touch-target-min: 48px;
     --mobile-window-title-height: 40px;
     --desktop-window-title-height: 28px;
+
+    /* Button sizing variables */
+    --close-button-size-mobile: 36px;
+    --close-button-size-desktop: 24px;
+    --close-button-padding: 2px;
+}
+
+/* Window control classes */
+.window-close-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  flex-shrink: 0;
+  background-color: transparent;
+  transition: background-color 150ms ease-in-out;
+  cursor: pointer;
+  position: relative;
+  z-index: 10;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  touch-action: manipulation;
+}
+
+.window-close-button:hover {
+  background-color: #dc2626; /* red-600 */
+}
+
+.window-close-button:active {
+  background-color: #b91c1c; /* red-700 */
+}
+
+.window-close-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #ef4444, 0 0 0 4px #000000; /* red-500 ring with black offset */
+}
+
+/* Responsive button sizing */
+@media (max-width: 640px) {
+  .window-close-button {
+    width: var(--close-button-size-mobile);
+    height: var(--close-button-size-mobile);
+    padding: var(--close-button-padding);
+  }
+}
+
+@media (min-width: 641px) {
+  .window-close-button {
+    width: var(--close-button-size-desktop);
+    height: var(--close-button-size-desktop);
+    padding: var(--close-button-padding);
+  }
+}
+
+/* Window resize improvements */
+.window-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background-color: #000000;
+  cursor: nw-resize;
+  touch-action: manipulation;
+  opacity: 0.5;
+  transition: opacity 150ms ease-in-out;
+}
+
+.window-resize-handle:hover {
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .window-resize-handle {
+    width: 20px !important;
+    height: 20px !important;
+    opacity: 0.7 !important;
+  }
+}
+
+@media (min-width: 769px) {
+  .window-resize-handle {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 /* Window-specific styles */
@@ -131,12 +215,6 @@
     font-size: 16px !important;
   }
   
-  /* Improve window resize handle for mobile */
-  .window-resize-handle {
-    width: 20px !important;
-    height: 20px !important;
-    opacity: 0.7 !important;
-  }
 }
 
 @keyframes mobile-slide-down {

--- a/components/menu-bar.tsx
+++ b/components/menu-bar.tsx
@@ -69,7 +69,7 @@ export function MenuBar() {
   return (
     <div
       ref={menuRef}
-      className="fixed top-0 left-0 right-0 h-7 bg-white border-b border-black flex items-center justify-between px-2 text-xs font-bold z-30"
+      className="fixed top-0 left-0 right-0 h-9 sm:h-7 bg-white border-b border-black flex items-center justify-between px-2 text-xs font-bold z-30"
       style={{ fontFamily: "Chicago, monospace" }}
     >
       {/* Left side - Menu items */}

--- a/components/window-frame.tsx
+++ b/components/window-frame.tsx
@@ -106,27 +106,11 @@ export function WindowFrame({
           <button
             onClick={handleClose}
             onTouchEnd={handleTouchEnd}
-            className={cn(
-              "flex items-center justify-center rounded flex-shrink-0",
-              "bg-transparent hover:bg-red-600 active:bg-red-700",
-              "transition-colors duration-150",
-              "focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-black",
-            )}
+            className="window-close-button"
             aria-label="Close window"
-            style={{
-              width: "var(--touch-target-min, 48px)",
-              height: "var(--touch-target-min, 48px)",
-              touchAction: "manipulation",
-              cursor: "pointer",
-              position: "relative",
-              zIndex: 10,
-              userSelect: "none",
-              WebkitUserSelect: "none",
-              WebkitTouchCallout: "none",
-            }}
             data-testid="window-close-button"
           >
-            <X size={16} className="pointer-events-none" />
+            <X size={14} className="pointer-events-none" />
           </button>
         </div>
 
@@ -151,7 +135,7 @@ export function WindowFrame({
         </div>
 
         {/* Resize Handle */}
-        <div className="window-resize-handle absolute bottom-0 right-0 w-4 h-4 bg-black cursor-nwse-resize touch-manipulation opacity-50 hover:opacity-100 transition-opacity" />
+        <div className="window-resize-handle" />
       </div>
     </div>
   )

--- a/hooks/use-window-manager.ts
+++ b/hooks/use-window-manager.ts
@@ -31,11 +31,18 @@ export function useWindowManager({ windowId, initialX, initialY, initialWidth, i
     const viewportHeight = window.innerHeight
     const minVisible = 50
 
+    // Responsive minimum sizes
+    const isMobile = viewportWidth < 768
+    const minWidth = isMobile ? Math.min(280, viewportWidth * 0.9) : 300
+    const minHeight = isMobile ? Math.min(200, viewportHeight * 0.4) : 200
+    const maxWidth = isMobile ? viewportWidth * 0.95 : viewportWidth - 100
+    const maxHeight = isMobile ? viewportHeight * 0.85 : viewportHeight - 100
+
     return {
       x: Math.max(minVisible - width, Math.min(x, viewportWidth - minVisible)),
       y: Math.max(0, Math.min(y, viewportHeight - minVisible)),
-      width: Math.min(width, viewportWidth),
-      height: Math.min(height, viewportHeight),
+      width: Math.max(minWidth, Math.min(width, maxWidth)),
+      height: Math.max(minHeight, Math.min(height, maxHeight)),
     }
   }, [])
 
@@ -143,8 +150,12 @@ export function useWindowManager({ windowId, initialX, initialY, initialWidth, i
         const deltaX = clientX - resizeStart.current.x
         const deltaY = clientY - resizeStart.current.y
 
-        const newWidth = Math.max(300, initialWindow.current.width + deltaX)
-        const newHeight = Math.max(200, initialWindow.current.height + deltaY)
+        const isMobile = window.innerWidth < 768
+        const minWidth = isMobile ? Math.min(280, window.innerWidth * 0.9) : 300
+        const minHeight = isMobile ? Math.min(200, window.innerHeight * 0.4) : 200
+
+        const newWidth = Math.max(minWidth, initialWindow.current.width + deltaX)
+        const newHeight = Math.max(minHeight, initialWindow.current.height + deltaY)
 
         const currentRect = windowRef.current.getBoundingClientRect()
         const constrained = constrainToViewport(currentRect.left, currentRect.top, newWidth, newHeight)


### PR DESCRIPTION
## Summary
- add shared close button and resize handle styles sized for desktop and mobile
- update window frame and manager logic to respect responsive minimum window sizing
- adjust the menu bar height to provide better touch targets on small screens

## Testing
- pnpm lint *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68d6c59206cc8326828ee4005cb928f8