### PR TITLE
Move desktop icons into menu bar dropdowns

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { DesktopIcon } from "@/components/desktop-icon"
 import { MenuBar } from "@/components/menu-bar"
 import { ThemeProvider } from "@/components/theme-manager"
 import { ThemeSwitcher } from "@/components/theme-manager"
@@ -23,7 +22,7 @@ import { AboutThisDesktopApp } from "@/components/about-this-desktop-app"
 import { WindowFrame } from "@/components/window-frame" // Keep this import
 import { useWindowStore, WindowState, WindowStore } from "@/store/window-store" // Import WindowState, WindowStore and useWindowStore
 
-import { appDefinitions, type AppId, getFinancialApps, getAIApps, getSystemApps, getToolApps } from "@/lib/app-definitions"
+import { appDefinitions, type AppId } from "@/lib/app-definitions"
 
 // Remove the local WindowState interface, as it's now imported from window-store.ts
 // interface WindowState {
@@ -144,97 +143,13 @@ export default function Home() {
         {/* Menu Bar */}
         <MenuBar />
 
-        {/* Desktop Icons */}
-        <div className="absolute inset-0 p-4 pt-16">
-          <div className="grid grid-cols-1 gap-4 w-fit">
-            {/* AI & Communication Section */}
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 px-2">
-                🤖 AI Assistant
-              </h3>
-              <div className="grid grid-cols-1 gap-2">
-                {getAIApps().map(app => (
-                  <DesktopIcon
-                    key={app.id}
-                    id={app.id}
-                    title={app.title}
-                    onClick={() => {
-                      if (app.requiresAuth && !user) {
-                        openWindow("supabase-login")
-                      } else {
-                        openWindow(app.id)
-                      }
-                    }}
-                    icon={`/images/${app.id}.png`}
-                  />
-                ))}
-              </div>
-            </div>
-
-            {/* Financial Apps Section */}
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 px-2">
-                💰 Financial Management
-              </h3>
-              <div className="grid grid-cols-1 gap-2">
-                {getFinancialApps().map(app => (
-                  <DesktopIcon
-                    key={app.id}
-                    id={app.id}
-                    title={app.title}
-                    onClick={() => {
-                      if (app.requiresAuth && !user) {
-                        openWindow("supabase-login")
-                      } else {
-                        openWindow(app.id)
-                      }
-                    }}
-                    icon={`/images/${app.id}.png`}
-                  />
-                ))}
-              </div>
-            </div>
-
-            {/* Tools Section */}
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 px-2">
-                🔧 Tools
-              </h3>
-              <div className="grid grid-cols-1 gap-2">
-                {getToolApps().map(app => (
-                  <DesktopIcon
-                    key={app.id}
-                    id={app.id}
-                    title={app.title}
-                    onClick={() => {
-                      if (app.requiresAuth && !user) {
-                        openWindow("supabase-login")
-                      } else {
-                        openWindow(app.id)
-                      }
-                    }}
-                    icon={`/images/${app.id}.png`}
-                  />
-                ))}
-              </div>
-            </div>
-
-            {/* System Apps Section */}
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 px-2">
-                ⚙️ System
-              </h3>
-              <div className="grid grid-cols-1 gap-2">
-                {getSystemApps().map(app => (
-                  <DesktopIcon
-                    key={app.id}
-                    id={app.id}
-                    title={app.title}
-                    onClick={() => openWindow(app.id)}
-                    icon={`/images/${app.id}.png`}
-                  />
-                ))}
-              </div>
+        {/* Desktop Content Area */}
+        <div className="flex-1 bg-green-500 p-8">
+          {/* Clean desktop space - ready for new content */}
+          <div className="h-full flex items-center justify-center">
+            <div className="text-center text-white">
+              <h2 className="text-3xl font-bold mb-4">Desktop Space Available</h2>
+              <p className="text-lg opacity-90">Apps now accessible via menu bar</p>
             </div>
           </div>
         </div>

--- a/components/menu-bar.tsx
+++ b/components/menu-bar.tsx
@@ -5,7 +5,13 @@ import { Clock } from "@/components/clock"
 import { VolumeControl } from "@/components/volume-control"
 import { useWindowStore } from "@/store/window-store"
 import { useAuthState } from "@/hooks/use-auth-state"
-import { appDefinitions } from "@/lib/app-definitions"
+import { appDefinitions, getAIApps, getFinancialApps, getSystemApps, getToolApps } from "@/lib/app-definitions"
+
+const categoryMenus = [
+  { id: "ai", emoji: "🤖", apps: () => getAIApps() },
+  { id: "financial", emoji: "💰", apps: () => getFinancialApps() },
+  { id: "tools", emoji: "🔧", apps: () => getToolApps() },
+]
 
 export function MenuBar() {
   const [activeMenu, setActiveMenu] = useState<string | null>(null)
@@ -73,53 +79,60 @@ export function MenuBar() {
       style={{ fontFamily: "Chicago, monospace" }}
     >
       {/* Left side - Menu items */}
-      <div className="flex items-center space-x-4">
+      <div className="flex items-center space-x-0">
         {/* Apple Menu */}
         <div className="relative">
           <button
+            className="px-2 py-1 hover:bg-blue-500 hover:text-white"
             onClick={() => handleMenuClick("apple")}
-            className="px-2 py-1 hover:bg-black hover:text-white transition-colors"
-            style={{ touchAction: "manipulation" }}
           >
             🍎
           </button>
           {activeMenu === "apple" && (
-            <div className="absolute top-full left-0 mt-1 bg-white border border-black shadow-lg min-w-48 z-40">
-              <button
-                onClick={() => openAppWindow("debug-console")}
-                className="block w-full text-left px-3 py-1 hover:bg-gray-100 border-b border-gray-200"
-              >
-                Debug Console
-              </button>
-              <button
-                onClick={() => openAppWindow("about-this-desktop")}
-                className="block w-full text-left px-3 py-1 hover:bg-gray-100"
-              >
-                About This Desktop
-              </button>
+            <div className="absolute top-full left-0 bg-white border border-black shadow-lg min-w-48 z-40">
+              {getSystemApps().map((app) => (
+                <button
+                  key={app.id}
+                  className="block w-full text-left px-3 py-2 hover:bg-blue-500 hover:text-white border-b border-gray-200 last:border-b-0"
+                  onClick={() => openAppWindow(app.id)}
+                >
+                  {app.title}
+                </button>
+              ))}
             </div>
           )}
         </div>
 
-        {/* Other menu placeholders */}
-        <button
-          onClick={() => handleMenuClick("file")}
-          className="px-2 py-1 hover:bg-black hover:text-white transition-colors opacity-50 cursor-not-allowed"
-        >
-          File
-        </button>
-        <button
-          onClick={() => handleMenuClick("edit")}
-          className="px-2 py-1 hover:bg-black hover:text-white transition-colors opacity-50 cursor-not-allowed"
-        >
-          Edit
-        </button>
-        <button
-          onClick={() => handleMenuClick("view")}
-          className="px-2 py-1 hover:bg-black hover:text-white transition-colors opacity-50 cursor-not-allowed"
-        >
-          View
-        </button>
+        {/* Category Menus */}
+        {categoryMenus.map((menu) => (
+          <div key={menu.id} className="relative">
+            <button
+              className="px-2 py-1 hover:bg-blue-500 hover:text-white"
+              onClick={() => handleMenuClick(menu.id)}
+            >
+              {menu.emoji}
+            </button>
+            {activeMenu === menu.id && (
+              <div className="absolute top-full left-0 bg-white border border-black shadow-lg min-w-48 z-40">
+                {menu.apps().map((app) => (
+                  <button
+                    key={app.id}
+                    className="block w-full text-left px-3 py-2 hover:bg-blue-500 hover:text-white border-b border-gray-200 last:border-b-0"
+                    onClick={() => {
+                      if (app.requiresAuth && !user) {
+                        openAppWindow("supabase-login")
+                      } else {
+                        openAppWindow(app.id)
+                      }
+                    }}
+                  >
+                    {app.title}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
       </div>
 
       {/* Right side - System controls */}


### PR DESCRIPTION
## Summary
- add AI, financial, and tools dropdown menus to the menu bar while keeping auth-aware launching
- surface system apps from the Apple menu and close menus when interacting elsewhere
- remove desktop icon grids in favor of open space messaging on the home screen

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_b_68d708ce56048326b5249343e5aa01d3