### PR TITLE
Move transaction summary to top of manager layout

### DIFF
--- a/components/transaction-manager.tsx
+++ b/components/transaction-manager.tsx
@@ -44,31 +44,29 @@ export function TransactionManager() {
   return (
     <div className="p-2 h-full overflow-auto">
       <h1 className="text-xl font-bold mb-2">Transactions</h1>
-      <div className="grid grid-cols-1 lg:grid-cols-4 gap-2 h-full">
-        <div className="lg:col-span-3 flex flex-col">
-          <TransactionFilters 
-            allTransactions={transactions} 
-            setFilteredTransactions={setFilteredTransactions} 
-          />
-          <div className="flex-1 overflow-auto">
-            {filteredTransactions.length === 0 ? (
-              <div className="text-center py-8">
-                <p className="text-gray-600 dark:text-gray-400">
-                  {transactions.length === 0 ? 'No transactions found.' : 'No transactions match your filters.'}
-                </p>
-              </div>
-            ) : (
-              <TransactionTable 
-                transactions={filteredTransactions} 
-                onTransactionUpdated={(updated) => {
-                  setFilteredTransactions(prev => prev.map(t => t.id === updated.id ? { ...t, ...updated } : t))
-                }}
-              />
-            )}
-          </div>
-        </div>
-        <div>
-          <TransactionSummary transactions={filteredTransactions} />
+      <div className="mb-2">
+        <TransactionSummary transactions={filteredTransactions} />
+      </div>
+      <div className="flex flex-col flex-1">
+        <TransactionFilters
+          allTransactions={transactions}
+          setFilteredTransactions={setFilteredTransactions}
+        />
+        <div className="flex-1 overflow-auto">
+          {filteredTransactions.length === 0 ? (
+            <div className="text-center py-8">
+              <p className="text-gray-600 dark:text-gray-400">
+                {transactions.length === 0 ? 'No transactions found.' : 'No transactions match your filters.'}
+              </p>
+            </div>
+          ) : (
+            <TransactionTable
+              transactions={filteredTransactions}
+              onTransactionUpdated={(updated) => {
+                setFilteredTransactions(prev => prev.map(t => t.id === updated.id ? { ...t, ...updated } : t))
+              }}
+            />
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- reposition the transaction summary above the main content in the manager layout
- convert the layout to a vertical flex column so the summary spans the full width

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dad41aec88832680152aed28571811