### PR TITLE
Add mortgage calculator service and desktop integration

### DIFF
--- a/app/api/mortgage-calculator/health/route.ts
+++ b/app/api/mortgage-calculator/health/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+
+const MORTGAGE_CALCULATOR_SERVICE_URL =
+  process.env.MORTGAGE_CALCULATOR_SERVICE_URL || 'http://mortgage-calculator:3004'
+
+export async function GET() {
+  try {
+    const response = await fetch(`${MORTGAGE_CALCULATOR_SERVICE_URL}/health`)
+
+    if (!response.ok) {
+      throw new Error(`Service responded with ${response.status}`)
+    }
+
+    const data = await response.json()
+
+    return NextResponse.json({
+      proxy: 'ok',
+      service: data,
+      serviceUrl: MORTGAGE_CALCULATOR_SERVICE_URL,
+    })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        proxy: 'ok',
+        service: 'error',
+        error: error instanceof Error ? error.message : 'Unknown error',
+        serviceUrl: MORTGAGE_CALCULATOR_SERVICE_URL,
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/mortgage-calculator/route.ts
+++ b/app/api/mortgage-calculator/route.ts
@@ -22,7 +22,23 @@ export async function POST(request: NextRequest) {
     const data = await response.json()
     return NextResponse.json(data)
   } catch (error) {
-    console.error('Mortgage calculator proxy error:', error)
-    return NextResponse.json({ error: 'Failed to calculate mortgage' }, { status: 500 })
+    console.error('Mortgage calculator proxy error:', {
+      error: error instanceof Error ? error.message : error,
+      serviceUrl: MORTGAGE_CALCULATOR_SERVICE_URL,
+      timestamp: new Date().toISOString(),
+    })
+
+    return NextResponse.json(
+      {
+        error: 'Failed to calculate mortgage',
+        details:
+          process.env.NODE_ENV === 'development'
+            ? error instanceof Error
+              ? error.message
+              : 'Unknown error'
+            : undefined,
+      },
+      { status: 500 },
+    )
   }
 }

--- a/app/api/mortgage-calculator/route.ts
+++ b/app/api/mortgage-calculator/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const MORTGAGE_CALCULATOR_SERVICE_URL =
+  process.env.MORTGAGE_CALCULATOR_SERVICE_URL || 'http://mortgage-calculator:3004'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const response = await fetch(`${MORTGAGE_CALCULATOR_SERVICE_URL}/calculate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Service responded with ${response.status}`)
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('Mortgage calculator proxy error:', error)
+    return NextResponse.json({ error: 'Failed to calculate mortgage' }, { status: 500 })
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,11 +21,11 @@ import { DebugConsole } from "@/components/debug-console"
 import { AboutThisDesktopApp } from "@/components/about-this-desktop-app"
 import { DesktopServiceSettings } from "@/components/desktop-service-settings"
 import { WindowFrame } from "@/components/window-frame"
-import { DesktopIcon } from "@/components/desktop-icon"
 import { useWindowStore, type WindowState, type WindowStore } from "@/store/window-store"
 import { useDesktopServiceStore } from "@/store/desktop-service-store"
 
 import { appDefinitions, type AppId } from "@/lib/app-definitions"
+import { MortgageCalculatorApp } from "@/components/mortgage-calculator-app"
 
 // Remove the local WindowState interface, as it's now imported from window-store.ts
 // interface WindowState {
@@ -98,10 +98,6 @@ export default function Home() {
     updateWindow(appId, { minimized: true })
   }
 
-  const bringToFront = (appId: AppId) => {
-    focusWindow(appId)
-  }
-
   // Remove these as they are handled by useWindowManager and updateWindow
   // const updateWindowPosition = (appId: AppId, position: { x: number; y: number }) => {
   //   setWindows(prev => prev.map(w =>
@@ -128,7 +124,7 @@ export default function Home() {
       case "transaction-manager":
         return <TransactionManager />
       case "mortgage-calculator":
-        return <ServiceApp serviceName="Mortgage Calculator" />
+        return <MortgageCalculatorApp />
       case "ai-chat-console":
         return <AIChatConsole />
       case "credits-manager":
@@ -183,16 +179,6 @@ export default function Home() {
       <div className="h-screen w-screen overflow-hidden bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 relative">
         {/* Menu Bar */}
         <MenuBar />
-
-        {/* Desktop Icons */}
-        <div className="absolute top-16 left-4 flex flex-col gap-4 z-10">
-          <DesktopIcon
-            id="mortgage-calculator"
-            title="Mortgage Calculator"
-            icon="/icons/calculator.svg"
-            onClick={() => openWindow("mortgage-calculator")}
-          />
-        </div>
 
         {/* Desktop Content Area */}
         <div className="h-full pt-12 pb-20 px-4">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ import { DebugConsole } from "@/components/debug-console"
 import { AboutThisDesktopApp } from "@/components/about-this-desktop-app"
 import { DesktopServiceSettings } from "@/components/desktop-service-settings"
 import { WindowFrame } from "@/components/window-frame"
+import { DesktopIcon } from "@/components/desktop-icon"
 import { useWindowStore, type WindowState, type WindowStore } from "@/store/window-store"
 import { useDesktopServiceStore } from "@/store/desktop-service-store"
 
@@ -126,6 +127,8 @@ export default function Home() {
         return <PaymentSourceBalances />
       case "transaction-manager":
         return <TransactionManager />
+      case "mortgage-calculator":
+        return <ServiceApp serviceName="Mortgage Calculator" />
       case "ai-chat-console":
         return <AIChatConsole />
       case "credits-manager":
@@ -180,6 +183,16 @@ export default function Home() {
       <div className="h-screen w-screen overflow-hidden bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 relative">
         {/* Menu Bar */}
         <MenuBar />
+
+        {/* Desktop Icons */}
+        <div className="absolute top-16 left-4 flex flex-col gap-4 z-10">
+          <DesktopIcon
+            id="mortgage-calculator"
+            title="Mortgage Calculator"
+            icon="/icons/calculator.svg"
+            onClick={() => openWindow("mortgage-calculator")}
+          />
+        </div>
 
         {/* Desktop Content Area */}
         <div className="h-full pt-12 pb-20 px-4">

--- a/components/mortgage-calculator-app.tsx
+++ b/components/mortgage-calculator-app.tsx
@@ -1,0 +1,349 @@
+"use client"
+
+import { useState, type ChangeEvent } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+interface MortgageFormState {
+  homePrice: number
+  downPayment: number
+  interestRate: number
+  loanTerm: number
+  startDate: string
+  propertyTaxes: number
+  homeInsurance: number
+  pmi: number
+  hoaFees: number
+}
+
+interface AmortizationEntry {
+  month: number
+  interest: number
+  principal: number
+  balance: number
+}
+
+interface MortgageResult {
+  monthlyPayment: number
+  monthlyPrincipalAndInterest: number
+  monthlyTaxes: number
+  monthlyInsurance: number
+  monthlyPmi: number
+  monthlyHoa: number
+  totalInterestPaid: number
+  amortization: AmortizationEntry[]
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+})
+
+const getServiceUrl = () => {
+  const baseUrl = process.env.NEXT_PUBLIC_MORTGAGE_CALCULATOR_URL || "http://localhost:3004"
+  return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+}
+
+const todayISO = () => new Date().toISOString().slice(0, 10)
+
+const createDefaultFormState = (): MortgageFormState => ({
+  homePrice: 450000,
+  downPayment: 90000,
+  interestRate: 6.25,
+  loanTerm: 30,
+  startDate: todayISO(),
+  propertyTaxes: 6000,
+  homeInsurance: 1200,
+  pmi: 0,
+  hoaFees: 125,
+})
+
+export function MortgageCalculatorApp() {
+  const [form, setForm] = useState<MortgageFormState>(() => createDefaultFormState())
+  const [result, setResult] = useState<MortgageResult | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleNumberChange = (field: keyof MortgageFormState) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value
+      setForm((prev) => ({
+        ...prev,
+        [field]: value === "" ? 0 : Number.parseFloat(value),
+      }))
+    }
+
+  const handleDateChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setForm((prev) => ({
+      ...prev,
+      startDate: event.target.value,
+    }))
+  }
+
+  const handleCalculate = async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`${getServiceUrl()}/calculate`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ...form,
+          startDate: form.startDate ? new Date(form.startDate).toISOString() : new Date().toISOString(),
+        }),
+      })
+
+      const payload = await response.json()
+
+      if (!response.ok) {
+        throw new Error(payload?.error || "Unable to calculate mortgage")
+      }
+
+      setResult(payload as MortgageResult)
+    } catch (err) {
+      setResult(null)
+      setError(err instanceof Error ? err.message : "Unexpected error calculating mortgage")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const totalPrincipal = result?.amortization.reduce((sum, entry) => sum + entry.principal, 0) ?? 0
+  const totalInterest = result?.amortization.reduce((sum, entry) => sum + entry.interest, 0) ?? 0
+
+  return (
+    <div className="p-6 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Mortgage Calculator 🤑</CardTitle>
+          <CardDescription>
+            Estimate your monthly mortgage payment with taxes, insurance, PMI, and HOA fees included.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="homePrice">Home Price</Label>
+              <Input
+                id="homePrice"
+                type="number"
+                inputMode="decimal"
+                value={form.homePrice}
+                onChange={handleNumberChange("homePrice")}
+                min={0}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="downPayment">Down Payment</Label>
+              <Input
+                id="downPayment"
+                type="number"
+                inputMode="decimal"
+                value={form.downPayment}
+                onChange={handleNumberChange("downPayment")}
+                min={0}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="interestRate">Interest Rate (%)</Label>
+              <Input
+                id="interestRate"
+                type="number"
+                inputMode="decimal"
+                step="0.01"
+                value={form.interestRate}
+                onChange={handleNumberChange("interestRate")}
+                min={0}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="loanTerm">Loan Term (years)</Label>
+              <Input
+                id="loanTerm"
+                type="number"
+                inputMode="decimal"
+                value={form.loanTerm}
+                onChange={handleNumberChange("loanTerm")}
+                min={1}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="startDate">Start Date</Label>
+              <Input
+                id="startDate"
+                type="date"
+                value={form.startDate}
+                onChange={handleDateChange}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="propertyTaxes">Annual Property Taxes</Label>
+              <Input
+                id="propertyTaxes"
+                type="number"
+                inputMode="decimal"
+                value={form.propertyTaxes}
+                onChange={handleNumberChange("propertyTaxes")}
+                min={0}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="homeInsurance">Annual Home Insurance</Label>
+              <Input
+                id="homeInsurance"
+                type="number"
+                inputMode="decimal"
+                value={form.homeInsurance}
+                onChange={handleNumberChange("homeInsurance")}
+                min={0}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="pmi">Annual PMI</Label>
+              <Input
+                id="pmi"
+                type="number"
+                inputMode="decimal"
+                value={form.pmi}
+                onChange={handleNumberChange("pmi")}
+                min={0}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="hoaFees">Monthly HOA Fees</Label>
+              <Input
+                id="hoaFees"
+                type="number"
+                inputMode="decimal"
+                value={form.hoaFees}
+                onChange={handleNumberChange("hoaFees")}
+                min={0}
+              />
+            </div>
+          </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>Calculation error</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex flex-wrap gap-3">
+            <Button onClick={handleCalculate} disabled={loading}>
+              {loading ? "Calculating..." : "Calculate"}
+            </Button>
+            {result && (
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setForm(createDefaultFormState())
+                  setResult(null)
+                  setError(null)
+                }}
+                disabled={loading}
+              >
+                Reset
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {result && (
+        <div className="grid gap-6 lg:grid-cols-[1.2fr,1fr]">
+          <Card className="order-2 lg:order-1">
+            <CardHeader>
+              <CardTitle>Amortization Schedule</CardTitle>
+              <CardDescription>Track how each monthly payment is split between principal and interest.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ScrollArea className="h-[360px] pr-4">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-16">Month</TableHead>
+                      <TableHead>Principal</TableHead>
+                      <TableHead>Interest</TableHead>
+                      <TableHead>Remaining Balance</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {result.amortization.map((entry) => (
+                      <TableRow key={entry.month}>
+                        <TableCell>{entry.month}</TableCell>
+                        <TableCell>{currencyFormatter.format(entry.principal)}</TableCell>
+                        <TableCell>{currencyFormatter.format(entry.interest)}</TableCell>
+                        <TableCell>{currencyFormatter.format(entry.balance)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                  <TableCaption>
+                    Total Principal Paid: {currencyFormatter.format(totalPrincipal)} • Total Interest Paid: {currencyFormatter.format(totalInterest)}
+                  </TableCaption>
+                </Table>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+
+          <Card className="order-1 lg:order-2">
+            <CardHeader>
+              <CardTitle>Monthly Payment Summary</CardTitle>
+              <CardDescription>Your estimated payment including escrow and association fees.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div className="flex items-center justify-between border-b pb-2 text-base font-semibold">
+                <span>Total Monthly Payment</span>
+                <span>{currencyFormatter.format(result.monthlyPayment)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Principal &amp; Interest</span>
+                <span>{currencyFormatter.format(result.monthlyPrincipalAndInterest)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Property Taxes</span>
+                <span>{currencyFormatter.format(result.monthlyTaxes)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Home Insurance</span>
+                <span>{currencyFormatter.format(result.monthlyInsurance)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>PMI</span>
+                <span>{currencyFormatter.format(result.monthlyPmi)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>HOA Fees</span>
+                <span>{currencyFormatter.format(result.monthlyHoa)}</span>
+              </div>
+              <div className="flex items-center justify-between border-t pt-2">
+                <span>Total Interest (life of loan)</span>
+                <span>{currencyFormatter.format(result.totalInterestPaid)}</span>
+              </div>
+              <div className="flex items-center justify-between text-muted-foreground">
+                <span>Loan Balance Paid Off</span>
+                <span>{currencyFormatter.format(totalPrincipal)}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/mortgage-calculator-app.tsx
+++ b/components/mortgage-calculator-app.tsx
@@ -53,8 +53,8 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 })
 
 const getServiceUrl = () => {
-  const baseUrl = process.env.NEXT_PUBLIC_MORTGAGE_CALCULATOR_URL || "http://localhost:3004"
-  return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+  // Use the Next.js API proxy so the browser never has to reach across the docker network
+  return "/api/mortgage-calculator"
 }
 
 const todayISO = () => new Date().toISOString().slice(0, 10)
@@ -98,7 +98,7 @@ export function MortgageCalculatorApp() {
     setError(null)
 
     try {
-      const response = await fetch(`${getServiceUrl()}/calculate`, {
+      const response = await fetch(getServiceUrl(), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -131,7 +131,7 @@ export function MortgageCalculatorApp() {
     <div className="p-6 space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle>Mortgage Calculator 🤑</CardTitle>
+          <CardTitle>💰 Mortgage Calculator</CardTitle>
           <CardDescription>
             Estimate your monthly mortgage payment with taxes, insurance, PMI, and HOA fees included.
           </CardDescription>

--- a/components/service-app.tsx
+++ b/components/service-app.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import CategoryLineChart from "./category-line-chart"
 import { PaymentSourceBalances } from "./payment-source-balances"
 import { CsvParserApp } from "./csv-parser-app"
+import { MortgageCalculatorApp } from "./mortgage-calculator-app"
 
 interface ServiceAppProps {
   serviceName: string
@@ -22,6 +23,10 @@ export function ServiceApp({ serviceName }: ServiceAppProps) {
 
     if (serviceName === "Credit") {
       return <PaymentSourceBalances />
+    }
+
+    if (serviceName === "Mortgage Calculator") {
+      return <MortgageCalculatorApp />
     }
 
     if (serviceName === "Voice Assistant") {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,12 @@ services:
       - NEXT_PUBLIC_FINANCE_API_URL=http://finance-api:3001
       - NEXT_PUBLIC_AI_CLOUD_API_URL=http://ai-cloud:3002
       - NEXT_PUBLIC_CHAT_SERVER_URL=ws://chat-server:3003
+      - NEXT_PUBLIC_MORTGAGE_CALCULATOR_URL=http://mortgage-calculator:3004
     depends_on:
       - finance-api
       - ai-cloud
       - chat-server
+      - mortgage-calculator
     networks:
       - optimal-os-net
 
@@ -52,6 +54,16 @@ services:
       - "3003:3003"
     environment:
       - PORT=3003
+    networks:
+      - optimal-os-net
+
+  mortgage-calculator:
+    build:
+      context: ./services/mortgage-calculator
+    ports:
+      - "3004:3004"
+    environment:
+      - PORT=3004
     networks:
       - optimal-os-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - NEXT_PUBLIC_FINANCE_API_URL=http://finance-api:3001
       - NEXT_PUBLIC_AI_CLOUD_API_URL=http://ai-cloud:3002
       - NEXT_PUBLIC_CHAT_SERVER_URL=ws://chat-server:3003
-      - NEXT_PUBLIC_MORTGAGE_CALCULATOR_URL=http://mortgage-calculator:3004
+      - NEXT_PUBLIC_MORTGAGE_CALCULATOR_URL=http://localhost:3004
+      - MORTGAGE_CALCULATOR_SERVICE_URL=http://mortgage-calculator:3004
     depends_on:
       - finance-api
       - ai-cloud

--- a/lib/app-definitions.ts
+++ b/lib/app-definitions.ts
@@ -6,13 +6,13 @@ export type AppId =
   | "category-line-chart"
   | "payment-source-balances"
   | "transaction-manager"
-  | "mortgage-calculator"
   | "ai-chat-console"
   | "credits-manager"
   | "service-app"
   | "debug-console"
   | "about-this-desktop"
   | "desktop-settings"
+  | "mortgage-calculator"
 
 export interface AppDefinition {
   id: AppId
@@ -70,7 +70,7 @@ export const appDefinitions: AppDefinition[] = [
     description: "Payment source balances with threshold filtering",
     canBeDesktop: true,
   },
-  { 
+  {
     id: "transaction-manager",
     title: "Transaction Manager",
     defaultWidth: APP_DIMENSIONS.XLARGE.width,
@@ -83,10 +83,11 @@ export const appDefinitions: AppDefinition[] = [
   {
     id: "mortgage-calculator",
     title: "Mortgage Calculator",
-    defaultWidth: APP_DIMENSIONS.LARGE.width,
+    defaultWidth: APP_DIMENSIONS.XLARGE.width,
     defaultHeight: APP_DIMENSIONS.LARGE.height,
+    requiresAuth: false,
     category: 'financial',
-    description: "Estimate mortgage payments with escrow details",
+    description: "Calculate mortgage payments with taxes and insurance",
     canBeDesktop: true,
   },
   

--- a/lib/app-definitions.ts
+++ b/lib/app-definitions.ts
@@ -6,6 +6,7 @@ export type AppId =
   | "category-line-chart"
   | "payment-source-balances"
   | "transaction-manager"
+  | "mortgage-calculator"
   | "ai-chat-console"
   | "credits-manager"
   | "service-app"
@@ -69,7 +70,7 @@ export const appDefinitions: AppDefinition[] = [
     description: "Payment source balances with threshold filtering",
     canBeDesktop: true,
   },
-  {
+  { 
     id: "transaction-manager",
     title: "Transaction Manager",
     defaultWidth: APP_DIMENSIONS.XLARGE.width,
@@ -77,6 +78,15 @@ export const appDefinitions: AppDefinition[] = [
     requiresAuth: true,
     category: 'financial',
     description: "Manage and view financial transactions",
+    canBeDesktop: true,
+  },
+  {
+    id: "mortgage-calculator",
+    title: "Mortgage Calculator",
+    defaultWidth: APP_DIMENSIONS.LARGE.width,
+    defaultHeight: APP_DIMENSIONS.LARGE.height,
+    category: 'financial',
+    description: "Estimate mortgage payments with escrow details",
     canBeDesktop: true,
   },
   

--- a/public/icons/calculator.svg
+++ b/public/icons/calculator.svg
@@ -1,0 +1,13 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="16" y="12" width="96" height="104" rx="16" fill="#1E293B"/>
+  <rect x="28" y="24" width="72" height="28" rx="8" fill="#38BDF8"/>
+  <rect x="28" y="60" width="20" height="20" rx="4" fill="#F97316"/>
+  <rect x="52" y="60" width="20" height="20" rx="4" fill="#FBBF24"/>
+  <rect x="76" y="60" width="24" height="20" rx="4" fill="#22C55E"/>
+  <rect x="28" y="84" width="20" height="20" rx="4" fill="#A855F7"/>
+  <rect x="52" y="84" width="20" height="20" rx="4" fill="#06B6D4"/>
+  <rect x="76" y="84" width="24" height="20" rx="4" fill="#F43F5E"/>
+  <circle cx="44" cy="38" r="6" fill="white"/>
+  <circle cx="64" cy="38" r="6" fill="white"/>
+  <circle cx="84" cy="38" r="6" fill="white"/>
+</svg>

--- a/services/mortgage-calculator/Dockerfile
+++ b/services/mortgage-calculator/Dockerfile
@@ -1,0 +1,17 @@
+# Stage 1: Build the application
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: Production image
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/dist ./dist
+RUN npm install --omit=dev
+
+EXPOSE 3004
+CMD ["node", "dist/index.js"]

--- a/services/mortgage-calculator/package.json
+++ b/services/mortgage-calculator/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mortgage-calculator-service",
+  "version": "1.0.0",
+  "description": "Mortgage calculator service for Optimal Dashboard V2",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.12",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/services/mortgage-calculator/src/index.ts
+++ b/services/mortgage-calculator/src/index.ts
@@ -1,0 +1,52 @@
+import express from "express"
+import cors from "cors"
+import { calculateMortgage, MortgageParams } from "./lib/calculator"
+
+const app = express()
+const port = Number(process.env.PORT) || 3004
+
+app.use(cors())
+app.use(express.json())
+
+const parseNumber = (value: unknown): number => {
+  const parsed = typeof value === "string" ? Number.parseFloat(value) : Number(value)
+  if (!Number.isFinite(parsed)) {
+    throw new Error("Invalid numeric value")
+  }
+  return parsed
+}
+
+app.post("/calculate", (req, res) => {
+  try {
+    const body = req.body ?? {}
+
+    const params: MortgageParams = {
+      homePrice: parseNumber(body.homePrice),
+      downPayment: parseNumber(body.downPayment),
+      interestRate: parseNumber(body.interestRate),
+      loanTerm: parseNumber(body.loanTerm),
+      startDate: body.startDate ? new Date(body.startDate) : new Date(),
+      propertyTaxes: parseNumber(body.propertyTaxes),
+      homeInsurance: parseNumber(body.homeInsurance),
+      pmi: parseNumber(body.pmi),
+      hoaFees: parseNumber(body.hoaFees ?? 0),
+    }
+
+    if (Number.isNaN(params.startDate.getTime())) {
+      throw new Error("Invalid start date")
+    }
+
+    const result = calculateMortgage(params)
+    res.json(result)
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : "Invalid input" })
+  }
+})
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" })
+})
+
+app.listen(port, () => {
+  console.log(`Mortgage calculator service listening at http://localhost:${port}`)
+})

--- a/services/mortgage-calculator/src/lib/calculator.ts
+++ b/services/mortgage-calculator/src/lib/calculator.ts
@@ -1,0 +1,108 @@
+export interface MortgageParams {
+  homePrice: number
+  downPayment: number
+  interestRate: number
+  loanTerm: number
+  startDate: Date
+  propertyTaxes: number
+  homeInsurance: number
+  pmi: number
+  hoaFees: number
+}
+
+export interface AmortizationEntry {
+  month: number
+  interest: number
+  principal: number
+  balance: number
+}
+
+export interface MortgageCalculationResult {
+  monthlyPayment: number
+  monthlyPrincipalAndInterest: number
+  monthlyTaxes: number
+  monthlyInsurance: number
+  monthlyPmi: number
+  monthlyHoa: number
+  totalInterestPaid: number
+  amortization: AmortizationEntry[]
+}
+
+const toCents = (value: number) => Math.round((value + Number.EPSILON) * 100) / 100
+
+export const calculateMortgage = (params: MortgageParams): MortgageCalculationResult => {
+  const loanAmount = params.homePrice - params.downPayment
+  const numberOfPayments = params.loanTerm * 12
+
+  if (!Number.isFinite(loanAmount) || loanAmount < 0) {
+    throw new Error("Loan amount must be zero or greater")
+  }
+
+  if (!Number.isFinite(numberOfPayments) || numberOfPayments <= 0) {
+    throw new Error("Loan term must be greater than zero")
+  }
+
+  const monthlyInterestRate = params.interestRate / 100 / 12
+
+  let monthlyPrincipalAndInterest: number
+  if (loanAmount === 0) {
+    monthlyPrincipalAndInterest = 0
+  } else if (monthlyInterestRate === 0) {
+    monthlyPrincipalAndInterest = loanAmount / numberOfPayments
+  } else {
+    const factor = Math.pow(1 + monthlyInterestRate, numberOfPayments)
+    monthlyPrincipalAndInterest = loanAmount * ((monthlyInterestRate * factor) / (factor - 1))
+  }
+
+  const monthlyTaxes = params.propertyTaxes / 12
+  const monthlyInsurance = params.homeInsurance / 12
+  const monthlyPmi = params.pmi / 12
+  const monthlyHoa = params.hoaFees
+
+  const totalMonthlyPayment =
+    monthlyPrincipalAndInterest +
+    monthlyTaxes +
+    monthlyInsurance +
+    monthlyPmi +
+    monthlyHoa
+
+  const amortization: AmortizationEntry[] = []
+  let balance = loanAmount
+  let totalInterestPaid = 0
+
+  if (loanAmount > 0 && monthlyInterestRate >= 0) {
+    for (let i = 1; i <= numberOfPayments; i++) {
+      const interest = balance * monthlyInterestRate
+      let principal = monthlyPrincipalAndInterest - interest
+
+      if (principal > balance) {
+        principal = balance
+      }
+
+      balance -= principal
+      totalInterestPaid += interest
+
+      amortization.push({
+        month: i,
+        interest: toCents(interest),
+        principal: toCents(principal),
+        balance: toCents(Math.max(balance, 0)),
+      })
+
+      if (balance <= 0) {
+        break
+      }
+    }
+  }
+
+  return {
+    monthlyPayment: toCents(totalMonthlyPayment),
+    monthlyPrincipalAndInterest: toCents(monthlyPrincipalAndInterest),
+    monthlyTaxes: toCents(monthlyTaxes),
+    monthlyInsurance: toCents(monthlyInsurance),
+    monthlyPmi: toCents(monthlyPmi),
+    monthlyHoa: toCents(monthlyHoa),
+    totalInterestPaid: toCents(totalInterestPaid),
+    amortization,
+  }
+}

--- a/services/mortgage-calculator/tsconfig.json
+++ b/services/mortgage-calculator/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- create a standalone Express-based mortgage calculator service with build tooling, Dockerfile, and amortization logic
- add a shadcn-styled MortgageCalculatorApp UI, surface it through the desktop launcher, and include a dedicated icon
- register the new service in app definitions and docker-compose to wire up environment variables and networking

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68dd4474cfd4832695a6e266a9c97dee