### PR TITLE
Add mortgage calculator service and frontend integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 
 # Optional
 NEXT_PUBLIC_ELECTRON_CONSOLE_URL=http://localhost:3000
+MORTGAGE_CALCULATOR_SERVICE_URL=http://localhost:3004
 # Optimal Desktop Enhanced Environment Configuration
 # Copy this file to .env.local and fill in your actual values
 

--- a/app/api/mortgage-calculator/route.ts
+++ b/app/api/mortgage-calculator/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const serviceUrl = process.env.MORTGAGE_CALCULATOR_SERVICE_URL;
+
+export async function POST(request: NextRequest) {
+  if (!serviceUrl) {
+    return NextResponse.json({ error: 'Service not configured' }, { status: 500 });
+  }
+
+  try {
+    const body = await request.json();
+    const response = await fetch(`${serviceUrl}/calculate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      return NextResponse.json({ error: `Service error: ${errorData}` }, { status: response.status });
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to connect to mortgage service' }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import { CsvCombinerApp } from "@/components/csv-combiner-app"
 import { CategoryLineChart } from "@/components/category-line-chart"
 import { PaymentSourceBalances } from "@/components/payment-source-balances"
 import { TransactionManager } from "@/components/transaction-manager"
+import { MortgageCalculatorApp } from "@/components/mortgage-calculator-app"
 import { AIChatConsole } from "@/components/ai-chat-console"
 import { CreditsManager } from "@/components/credits-manager"
 import { ServiceApp } from "@/components/service-app"
@@ -129,6 +130,8 @@ export default function Home() {
         return <PaymentSourceBalances />
       case "transaction-manager":
         return <TransactionManager />
+      case "mortgage-calculator":
+        return <MortgageCalculatorApp />
       case "ai-chat-console":
         return <AIChatConsole />
       case "credits-manager":

--- a/components/mortgage-calculator-app.tsx
+++ b/components/mortgage-calculator-app.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+
+export function MortgageCalculatorApp() {
+  const [homePrice, setHomePrice] = useState(450000);
+  const [downPayment, setDownPayment] = useState(90000);
+  const [interestRate, setInterestRate] = useState(6.25);
+  const [loanTerm, setLoanTerm] = useState(30);
+  const [monthlyPayment, setMonthlyPayment] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleCalculate = async () => {
+    setLoading(true);
+    setError(null);
+    setMonthlyPayment(null);
+
+    try {
+      const response = await fetch('/api/mortgage-calculator', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ homePrice, downPayment, interestRate, loanTerm }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to calculate mortgage');
+      }
+
+      const result = await response.json();
+      setMonthlyPayment(result.monthlyPayment);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>💰 Mortgage Calculator</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="homePrice">Home Price</Label>
+            <Input id="homePrice" type="number" value={homePrice} onChange={(e) => setHomePrice(Number(e.target.value))} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="downPayment">Down Payment</Label>
+            <Input id="downPayment" type="number" value={downPayment} onChange={(e) => setDownPayment(Number(e.target.value))} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="interestRate">Interest Rate (%)</Label>
+            <Input id="interestRate" type="number" value={interestRate} onChange={(e) => setInterestRate(Number(e.target.value))} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="loanTerm">Loan Term (Years)</Label>
+            <Input id="loanTerm" type="number" value={loanTerm} onChange={(e) => setLoanTerm(Number(e.target.value))} />
+          </div>
+        </div>
+        <Button onClick={handleCalculate} disabled={loading}>
+          {loading ? 'Calculating...' : 'Calculate'}
+        </Button>
+        {error && (
+          <Alert variant="destructive">
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        {monthlyPayment !== null && (
+          <Alert>
+            <AlertTitle>Your Estimated Monthly Payment:</AlertTitle>
+            <AlertDescription className="text-2xl font-bold">
+              {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(monthlyPayment)}
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,12 @@ services:
       - NEXT_PUBLIC_FINANCE_API_URL=http://finance-api:3001
       - NEXT_PUBLIC_AI_CLOUD_API_URL=http://ai-cloud:3002
       - NEXT_PUBLIC_CHAT_SERVER_URL=ws://chat-server:3003
+      - MORTGAGE_CALCULATOR_SERVICE_URL=http://mortgage-calculator:3004
     depends_on:
       - finance-api
       - ai-cloud
       - chat-server
+      - mortgage-calculator
     networks:
       - optimal-os-net
 
@@ -52,6 +54,14 @@ services:
       - "3003:3003"
     environment:
       - PORT=3003
+    networks:
+      - optimal-os-net
+
+  mortgage-calculator:
+    build:
+      context: ./services/mortgage-calculator
+    ports:
+      - "3004:3004"
     networks:
       - optimal-os-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - NEXT_PUBLIC_FINANCE_API_URL=http://finance-api:3001
       - NEXT_PUBLIC_AI_CLOUD_API_URL=http://ai-cloud:3002
       - NEXT_PUBLIC_CHAT_SERVER_URL=ws://chat-server:3003
+      # Mortgage calculator microservice URL used by the Next.js API proxy
       - MORTGAGE_CALCULATOR_SERVICE_URL=http://mortgage-calculator:3004
     depends_on:
       - finance-api

--- a/lib/app-definitions.ts
+++ b/lib/app-definitions.ts
@@ -7,6 +7,7 @@ export type AppId =
   | "category-line-chart"
   | "payment-source-balances"
   | "transaction-manager"
+  | "mortgage-calculator"
   | "ai-chat-console"
   | "credits-manager"
   | "service-app"
@@ -79,6 +80,15 @@ export const appDefinitions: AppDefinition[] = [
     category: 'financial',
     description: "Manage and view financial transactions",
     canBeDesktop: true,
+  },
+  {
+    id: "mortgage-calculator",
+    title: "Mortgage Calculator",
+    defaultWidth: 500,
+    defaultHeight: 450,
+    category: 'financial',
+    description: "A simple mortgage calculator.",
+    canBeDesktop: false,
   },
   
   // Tools

--- a/services/mortgage-calculator/Dockerfile
+++ b/services/mortgage-calculator/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+EXPOSE 3004
+
+CMD [ "npm", "start" ]

--- a/services/mortgage-calculator/package.json
+++ b/services/mortgage-calculator/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mortgage-calculator",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.12",
+    "@types/express": "^4.17.13",
+    "ts-node-dev": "^1.1.8",
+    "typescript": "^4.5.4"
+  }
+}

--- a/services/mortgage-calculator/src/index.ts
+++ b/services/mortgage-calculator/src/index.ts
@@ -1,0 +1,27 @@
+import express from 'express';
+import cors from 'cors';
+import { calculateMortgage, MortgageParams } from './lib/calculator';
+
+const app = express();
+const port = process.env.PORT || 3004;
+
+app.use(cors());
+app.use(express.json());
+
+app.post('/calculate', (req, res) => {
+  try {
+    const params: MortgageParams = req.body;
+    const result = calculateMortgage(params);
+    res.json(result);
+  } catch (error) {
+    res.status(400).json({ error: 'Invalid calculation request' });
+  }
+});
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(port, () => {
+  console.log(`Mortgage calculator service listening at http://localhost:${port}`);
+});

--- a/services/mortgage-calculator/src/lib/calculator.ts
+++ b/services/mortgage-calculator/src/lib/calculator.ts
@@ -1,0 +1,32 @@
+export interface MortgageParams {
+  homePrice: number;
+  downPayment: number;
+  interestRate: number;
+  loanTerm: number;
+}
+
+export interface MortgageResult {
+  monthlyPayment: number;
+}
+
+export const calculateMortgage = (params: MortgageParams): MortgageResult => {
+  const { homePrice, downPayment, interestRate, loanTerm } = params;
+  const loanAmount = homePrice - downPayment;
+  const monthlyInterestRate = interestRate / 100 / 12;
+  const numberOfPayments = loanTerm * 12;
+
+  if (loanAmount <= 0) {
+    return { monthlyPayment: 0 };
+  }
+
+  if (monthlyInterestRate === 0) {
+    return { monthlyPayment: loanAmount / numberOfPayments };
+  }
+
+  const monthlyPayment = 
+    loanAmount * 
+    (monthlyInterestRate * Math.pow(1 + monthlyInterestRate, numberOfPayments)) / 
+    (Math.pow(1 + monthlyInterestRate, numberOfPayments) - 1);
+
+  return { monthlyPayment };
+};

--- a/services/mortgage-calculator/tsconfig.json
+++ b/services/mortgage-calculator/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated mortgage-calculator microservice with TypeScript build, Dockerfile, and Express endpoints
- expose a Next.js API proxy and menu registration so the desktop can reach the mortgage service via docker-compose wiring
- create a client mortgage calculator UI that posts to the proxy and displays formatted payment results

## Testing
- pnpm lint *(fails: command requires interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68dd5f21cf048326a64b083d6503c837