### PR TITLE
Add mortgage calculator accessible via financial menu

### DIFF
--- a/app/api/mortgage-calculator/route.ts
+++ b/app/api/mortgage-calculator/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+interface MortgageParams {
+  homePrice: number;
+  downPayment: number;
+  interestRate: number;
+  loanTerm: number;
+}
+
+interface MortgageResult {
+  monthlyPayment: number;
+}
+
+function calculateMortgage(params: MortgageParams): MortgageResult {
+  const { homePrice, downPayment, interestRate, loanTerm } = params;
+  const loanAmount = homePrice - downPayment;
+  const monthlyInterestRate = interestRate / 100 / 12;
+  const numberOfPayments = loanTerm * 12;
+
+  if (loanAmount <= 0) {
+    return { monthlyPayment: 0 };
+  }
+
+  if (monthlyInterestRate === 0) {
+    return { monthlyPayment: loanAmount / numberOfPayments };
+  }
+
+  const monthlyPayment =
+    loanAmount *
+    (monthlyInterestRate * Math.pow(1 + monthlyInterestRate, numberOfPayments)) /
+    (Math.pow(1 + monthlyInterestRate, numberOfPayments) - 1);
+
+  return { monthlyPayment };
+}
+
+function validateMortgageParams(body: any): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (typeof body.homePrice !== 'number' || body.homePrice <= 0) {
+    errors.push('homePrice must be a positive number');
+  }
+
+  if (typeof body.downPayment !== 'number' || body.downPayment < 0) {
+    errors.push('downPayment must be a non-negative number');
+  }
+
+  if (typeof body.interestRate !== 'number' || body.interestRate < 0) {
+    errors.push('interestRate must be a non-negative number');
+  }
+
+  if (typeof body.loanTerm !== 'number' || body.loanTerm <= 0) {
+    errors.push('loanTerm must be a positive number');
+  }
+
+  if (errors.length === 0 && body.downPayment > body.homePrice) {
+    errors.push('downPayment cannot be greater than homePrice');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const validation = validateMortgageParams(body);
+    if (!validation.valid) {
+      return NextResponse.json(
+        {
+          error: 'Invalid input parameters',
+          details: validation.errors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const result = calculateMortgage(body);
+
+    if (isNaN(result.monthlyPayment)) {
+      return NextResponse.json(
+        {
+          error: 'Calculation resulted in invalid value',
+        },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Invalid request format',
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import { CsvCombinerApp } from "@/components/csv-combiner-app"
 import { CategoryLineChart } from "@/components/category-line-chart"
 import { PaymentSourceBalances } from "@/components/payment-source-balances"
 import { TransactionManager } from "@/components/transaction-manager"
+import { MortgageCalculatorApp } from "@/components/mortgage-calculator-app"
 import { AIChatConsole } from "@/components/ai-chat-console"
 import { CreditsManager } from "@/components/credits-manager"
 import { ServiceApp } from "@/components/service-app"
@@ -129,6 +130,8 @@ export default function Home() {
         return <PaymentSourceBalances />
       case "transaction-manager":
         return <TransactionManager />
+      case "mortgage-calculator":
+        return <MortgageCalculatorApp />
       case "ai-chat-console":
         return <AIChatConsole />
       case "credits-manager":

--- a/components/mortgage-calculator-app.tsx
+++ b/components/mortgage-calculator-app.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+
+export function MortgageCalculatorApp() {
+  const [homePrice, setHomePrice] = useState(450000);
+  const [downPayment, setDownPayment] = useState(90000);
+  const [interestRate, setInterestRate] = useState(6.25);
+  const [loanTerm, setLoanTerm] = useState(30);
+  const [monthlyPayment, setMonthlyPayment] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleCalculate = async () => {
+    setLoading(true);
+    setError(null);
+    setMonthlyPayment(null);
+
+    try {
+      const response = await fetch('/api/mortgage-calculator', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ homePrice, downPayment, interestRate, loanTerm }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to calculate mortgage');
+      }
+
+      const result = await response.json();
+      setMonthlyPayment(result.monthlyPayment);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>💰 Mortgage Calculator</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="homePrice">Home Price</Label>
+            <Input
+              id="homePrice"
+              type="number"
+              value={homePrice}
+              onChange={(e) => setHomePrice(Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="downPayment">Down Payment</Label>
+            <Input
+              id="downPayment"
+              type="number"
+              value={downPayment}
+              onChange={(e) => setDownPayment(Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="interestRate">Interest Rate (%)</Label>
+            <Input
+              id="interestRate"
+              type="number"
+              step="0.01"
+              value={interestRate}
+              onChange={(e) => setInterestRate(Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="loanTerm">Loan Term (Years)</Label>
+            <Input
+              id="loanTerm"
+              type="number"
+              value={loanTerm}
+              onChange={(e) => setLoanTerm(Number(e.target.value))}
+            />
+          </div>
+        </div>
+        <Button onClick={handleCalculate} disabled={loading} className="w-full">
+          {loading ? 'Calculating...' : 'Calculate Monthly Payment'}
+        </Button>
+        {error && (
+          <Alert variant="destructive">
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        {monthlyPayment !== null && (
+          <Alert>
+            <AlertTitle>Your Estimated Monthly Payment:</AlertTitle>
+            <AlertDescription className="text-2xl font-bold">
+              {new Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: 'USD',
+              }).format(monthlyPayment)}
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/app-definitions.ts
+++ b/lib/app-definitions.ts
@@ -7,6 +7,7 @@ export type AppId =
   | "category-line-chart"
   | "payment-source-balances"
   | "transaction-manager"
+  | "mortgage-calculator"
   | "ai-chat-console"
   | "credits-manager"
   | "service-app"
@@ -80,7 +81,16 @@ export const appDefinitions: AppDefinition[] = [
     description: "Manage and view financial transactions",
     canBeDesktop: true,
   },
-  
+  {
+    id: "mortgage-calculator",
+    title: "Mortgage Calculator",
+    defaultWidth: 500,
+    defaultHeight: 450,
+    category: 'financial',
+    description: "Calculate monthly mortgage payments",
+    canBeDesktop: false,
+  },
+
   // Tools
   {
     id: "csv-parser",


### PR DESCRIPTION
## Summary
- add a mortgage calculation API route with input validation and server-side math
- build a client-side mortgage calculator UI that posts to the API and shows results
- register the app in financial definitions and render it from the 💰 menu without a desktop icon

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_b_68dd6a8521ec8326b0523e5dec883eb5