### PR TITLE
Add comprehensive mortgage calculator app

### DIFF
--- a/app/api/mortgage-calculator/route.ts
+++ b/app/api/mortgage-calculator/route.ts
@@ -5,10 +5,41 @@ interface MortgageParams {
   downPayment: number;
   interestRate: number;
   loanTerm: number;
+  includeTaxesAndCosts: boolean;
+  propertyTaxes: number;
+  propertyTaxType: 'percent' | 'dollar';
+  homeInsurance: number;
+  homeInsuranceType: 'percent' | 'dollar';
+  pmiInsurance: number;
+  pmiInsuranceType: 'percent' | 'dollar';
+  hoaFee: number;
+  hoaFeeType: 'percent' | 'dollar';
+  otherCosts: number;
+  otherCostsType: 'percent' | 'dollar';
 }
 
 interface MortgageResult {
   monthlyPayment: number;
+  loanAmount: number;
+  totalInterest: number;
+  monthlyBreakdown: {
+    principalAndInterest: number;
+    propertyTax: number;
+    homeInsurance: number;
+    pmiInsurance: number;
+    hoaFee: number;
+    otherCosts: number;
+    totalMonthlyPayment: number;
+  };
+  annualBreakdown: {
+    principalAndInterest: number;
+    propertyTax: number;
+    homeInsurance: number;
+    pmiInsurance: number;
+    hoaFee: number;
+    otherCosts: number;
+    totalAnnualPayment: number;
+  };
 }
 
 function calculateMortgage(params: MortgageParams): MortgageResult {
@@ -17,20 +48,90 @@ function calculateMortgage(params: MortgageParams): MortgageResult {
   const monthlyInterestRate = interestRate / 100 / 12;
   const numberOfPayments = loanTerm * 12;
 
+  let monthlyPrincipalAndInterest = 0;
+
   if (loanAmount <= 0) {
-    return { monthlyPayment: 0 };
+    monthlyPrincipalAndInterest = 0;
+  } else if (monthlyInterestRate === 0) {
+    monthlyPrincipalAndInterest = loanAmount / numberOfPayments;
+  } else {
+    monthlyPrincipalAndInterest =
+      loanAmount *
+      (monthlyInterestRate * Math.pow(1 + monthlyInterestRate, numberOfPayments)) /
+      (Math.pow(1 + monthlyInterestRate, numberOfPayments) - 1);
   }
 
-  if (monthlyInterestRate === 0) {
-    return { monthlyPayment: loanAmount / numberOfPayments };
+  const totalInterest = monthlyPrincipalAndInterest * numberOfPayments - loanAmount;
+
+  let monthlyPropertyTax = 0;
+  let monthlyHomeInsurance = 0;
+  let monthlyPmiInsurance = 0;
+  let monthlyHoaFee = 0;
+  let monthlyOtherCosts = 0;
+
+  if (params.includeTaxesAndCosts) {
+    if (params.propertyTaxType === 'percent') {
+      monthlyPropertyTax = (homePrice * params.propertyTaxes) / 100 / 12;
+    } else {
+      monthlyPropertyTax = params.propertyTaxes / 12;
+    }
+
+    if (params.homeInsuranceType === 'percent') {
+      monthlyHomeInsurance = (homePrice * params.homeInsurance) / 100 / 12;
+    } else {
+      monthlyHomeInsurance = params.homeInsurance / 12;
+    }
+
+    if (params.pmiInsuranceType === 'percent') {
+      monthlyPmiInsurance = (loanAmount * params.pmiInsurance) / 100 / 12;
+    } else {
+      monthlyPmiInsurance = params.pmiInsurance / 12;
+    }
+
+    if (params.hoaFeeType === 'percent') {
+      monthlyHoaFee = (homePrice * params.hoaFee) / 100 / 12;
+    } else {
+      monthlyHoaFee = params.hoaFee / 12;
+    }
+
+    if (params.otherCostsType === 'percent') {
+      monthlyOtherCosts = (homePrice * params.otherCosts) / 100 / 12;
+    } else {
+      monthlyOtherCosts = params.otherCosts / 12;
+    }
   }
 
-  const monthlyPayment =
-    loanAmount *
-    (monthlyInterestRate * Math.pow(1 + monthlyInterestRate, numberOfPayments)) /
-    (Math.pow(1 + monthlyInterestRate, numberOfPayments) - 1);
+  const totalMonthlyPayment =
+    monthlyPrincipalAndInterest +
+    monthlyPropertyTax +
+    monthlyHomeInsurance +
+    monthlyPmiInsurance +
+    monthlyHoaFee +
+    monthlyOtherCosts;
 
-  return { monthlyPayment };
+  return {
+    monthlyPayment: monthlyPrincipalAndInterest,
+    loanAmount,
+    totalInterest,
+    monthlyBreakdown: {
+      principalAndInterest: monthlyPrincipalAndInterest,
+      propertyTax: monthlyPropertyTax,
+      homeInsurance: monthlyHomeInsurance,
+      pmiInsurance: monthlyPmiInsurance,
+      hoaFee: monthlyHoaFee,
+      otherCosts: monthlyOtherCosts,
+      totalMonthlyPayment,
+    },
+    annualBreakdown: {
+      principalAndInterest: monthlyPrincipalAndInterest * 12,
+      propertyTax: monthlyPropertyTax * 12,
+      homeInsurance: monthlyHomeInsurance * 12,
+      pmiInsurance: monthlyPmiInsurance * 12,
+      hoaFee: monthlyHoaFee * 12,
+      otherCosts: monthlyOtherCosts * 12,
+      totalAnnualPayment: totalMonthlyPayment * 12,
+    },
+  };
 }
 
 function validateMortgageParams(body: any): { valid: boolean; errors: string[] } {
@@ -52,6 +153,34 @@ function validateMortgageParams(body: any): { valid: boolean; errors: string[] }
     errors.push('loanTerm must be a positive number');
   }
 
+  if (typeof body.includeTaxesAndCosts !== 'boolean') {
+    errors.push('includeTaxesAndCosts must be a boolean');
+  }
+
+  if (body.includeTaxesAndCosts) {
+    const additionalFields = ['propertyTaxes', 'homeInsurance', 'pmiInsurance', 'hoaFee', 'otherCosts'];
+
+    additionalFields.forEach((field) => {
+      if (typeof body[field] !== 'number' || body[field] < 0) {
+        errors.push(`${field} must be a non-negative number`);
+      }
+    });
+
+    const typeFields = [
+      'propertyTaxType',
+      'homeInsuranceType',
+      'pmiInsuranceType',
+      'hoaFeeType',
+      'otherCostsType',
+    ];
+
+    typeFields.forEach((field) => {
+      if (!['percent', 'dollar'].includes(body[field])) {
+        errors.push(`${field} must be either 'percent' or 'dollar'`);
+      }
+    });
+  }
+
   if (errors.length === 0 && body.downPayment > body.homePrice) {
     errors.push('downPayment cannot be greater than homePrice');
   }
@@ -70,7 +199,7 @@ export async function POST(request: NextRequest) {
           error: 'Invalid input parameters',
           details: validation.errors,
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -81,7 +210,7 @@ export async function POST(request: NextRequest) {
         {
           error: 'Calculation resulted in invalid value',
         },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
@@ -91,7 +220,7 @@ export async function POST(request: NextRequest) {
       {
         error: 'Invalid request format',
       },
-      { status: 400 }
+      { status: 400 },
     );
   }
 }

--- a/components/mortgage-calculator-app.tsx
+++ b/components/mortgage-calculator-app.tsx
@@ -6,20 +6,68 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
+
+interface MortgageResult {
+  monthlyPayment: number;
+  loanAmount: number;
+  totalInterest: number;
+  monthlyBreakdown: {
+    principalAndInterest: number;
+    propertyTax: number;
+    homeInsurance: number;
+    pmiInsurance: number;
+    hoaFee: number;
+    otherCosts: number;
+    totalMonthlyPayment: number;
+  };
+  annualBreakdown: {
+    principalAndInterest: number;
+    propertyTax: number;
+    homeInsurance: number;
+    pmiInsurance: number;
+    hoaFee: number;
+    otherCosts: number;
+    totalAnnualPayment: number;
+  };
+}
 
 export function MortgageCalculatorApp() {
   const [homePrice, setHomePrice] = useState(450000);
   const [downPayment, setDownPayment] = useState(90000);
   const [interestRate, setInterestRate] = useState(6.25);
   const [loanTerm, setLoanTerm] = useState(30);
-  const [monthlyPayment, setMonthlyPayment] = useState<number | null>(null);
+
+  const [includeTaxesAndCosts, setIncludeTaxesAndCosts] = useState(true);
+
+  const [propertyTaxes, setPropertyTaxes] = useState(1.2);
+  const [propertyTaxType, setPropertyTaxType] = useState<'percent' | 'dollar'>('percent');
+  const [homeInsurance, setHomeInsurance] = useState(1500);
+  const [homeInsuranceType, setHomeInsuranceType] = useState<'percent' | 'dollar'>('dollar');
+  const [pmiInsurance, setPmiInsurance] = useState(0);
+  const [pmiInsuranceType, setPmiInsuranceType] = useState<'percent' | 'dollar'>('dollar');
+  const [hoaFee, setHoaFee] = useState(0);
+  const [hoaFeeType, setHoaFeeType] = useState<'percent' | 'dollar'>('dollar');
+  const [otherCosts, setOtherCosts] = useState(0);
+  const [otherCostsType, setOtherCostsType] = useState<'percent' | 'dollar'>('dollar');
+
+  const [result, setResult] = useState<MortgageResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(amount);
+  };
 
   const handleCalculate = async () => {
     setLoading(true);
     setError(null);
-    setMonthlyPayment(null);
+    setResult(null);
 
     try {
       const response = await fetch('/api/mortgage-calculator', {
@@ -27,7 +75,23 @@ export function MortgageCalculatorApp() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ homePrice, downPayment, interestRate, loanTerm }),
+        body: JSON.stringify({
+          homePrice,
+          downPayment,
+          interestRate,
+          loanTerm,
+          includeTaxesAndCosts,
+          propertyTaxes,
+          propertyTaxType,
+          homeInsurance,
+          homeInsuranceType,
+          pmiInsurance,
+          pmiInsuranceType,
+          hoaFee,
+          hoaFeeType,
+          otherCosts,
+          otherCostsType,
+        }),
       });
 
       if (!response.ok) {
@@ -35,8 +99,8 @@ export function MortgageCalculatorApp() {
         throw new Error(errorData.error || 'Failed to calculate mortgage');
       }
 
-      const result = await response.json();
-      setMonthlyPayment(result.monthlyPayment);
+      const calculationResult = await response.json();
+      setResult(calculationResult);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unexpected error occurred');
     } finally {
@@ -45,71 +109,298 @@ export function MortgageCalculatorApp() {
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>💰 Mortgage Calculator</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="homePrice">Home Price</Label>
-            <Input
-              id="homePrice"
-              type="number"
-              value={homePrice}
-              onChange={(e) => setHomePrice(Number(e.target.value))}
-            />
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>💰 Mortgage Calculator</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="homePrice">Home Price</Label>
+              <Input
+                id="homePrice"
+                type="number"
+                value={homePrice}
+                onChange={(e) => setHomePrice(Number(e.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="downPayment">Down Payment</Label>
+              <Input
+                id="downPayment"
+                type="number"
+                value={downPayment}
+                onChange={(e) => setDownPayment(Number(e.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="interestRate">Interest Rate (%)</Label>
+              <Input
+                id="interestRate"
+                type="number"
+                step="0.01"
+                value={interestRate}
+                onChange={(e) => setInterestRate(Number(e.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="loanTerm">Loan Term (Years)</Label>
+              <Input
+                id="loanTerm"
+                type="number"
+                value={loanTerm}
+                onChange={(e) => setLoanTerm(Number(e.target.value))}
+              />
+            </div>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="downPayment">Down Payment</Label>
-            <Input
-              id="downPayment"
-              type="number"
-              value={downPayment}
-              onChange={(e) => setDownPayment(Number(e.target.value))}
+
+          <Separator />
+
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="includeTaxesAndCosts"
+              checked={includeTaxesAndCosts}
+              onCheckedChange={(checked) => setIncludeTaxesAndCosts(checked as boolean)}
             />
+            <Label htmlFor="includeTaxesAndCosts" className="font-medium">
+              Include Taxes & Costs Below
+            </Label>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="interestRate">Interest Rate (%)</Label>
-            <Input
-              id="interestRate"
-              type="number"
-              step="0.01"
-              value={interestRate}
-              onChange={(e) => setInterestRate(Number(e.target.value))}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="loanTerm">Loan Term (Years)</Label>
-            <Input
-              id="loanTerm"
-              type="number"
-              value={loanTerm}
-              onChange={(e) => setLoanTerm(Number(e.target.value))}
-            />
-          </div>
-        </div>
-        <Button onClick={handleCalculate} disabled={loading} className="w-full">
-          {loading ? 'Calculating...' : 'Calculate Monthly Payment'}
-        </Button>
-        {error && (
-          <Alert variant="destructive">
-            <AlertTitle>Error</AlertTitle>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
-        {monthlyPayment !== null && (
-          <Alert>
-            <AlertTitle>Your Estimated Monthly Payment:</AlertTitle>
-            <AlertDescription className="text-2xl font-bold">
-              {new Intl.NumberFormat('en-US', {
-                style: 'currency',
-                currency: 'USD',
-              }).format(monthlyPayment)}
-            </AlertDescription>
-          </Alert>
-        )}
-      </CardContent>
-    </Card>
+
+          {includeTaxesAndCosts && (
+            <div className="space-y-4 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+              <h4 className="font-medium text-sm text-gray-700 dark:text-gray-300">
+                Annual Tax & Cost
+              </h4>
+
+              <div className="grid grid-cols-3 gap-2 items-end">
+                <div className="space-y-2">
+                  <Label htmlFor="propertyTaxes" className="text-sm">
+                    Property Taxes
+                  </Label>
+                  <Input
+                    id="propertyTaxes"
+                    type="number"
+                    step="0.01"
+                    value={propertyTaxes}
+                    onChange={(e) => setPropertyTaxes(Number(e.target.value))}
+                  />
+                </div>
+                <Select
+                  value={propertyTaxType}
+                  onValueChange={(value: 'percent' | 'dollar') => setPropertyTaxType(value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="percent">%</SelectItem>
+                    <SelectItem value="dollar">$</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid grid-cols-3 gap-2 items-end">
+                <div className="space-y-2">
+                  <Label htmlFor="homeInsurance" className="text-sm">
+                    Home Insurance
+                  </Label>
+                  <Input
+                    id="homeInsurance"
+                    type="number"
+                    value={homeInsurance}
+                    onChange={(e) => setHomeInsurance(Number(e.target.value))}
+                  />
+                </div>
+                <Select
+                  value={homeInsuranceType}
+                  onValueChange={(value: 'percent' | 'dollar') => setHomeInsuranceType(value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="percent">%</SelectItem>
+                    <SelectItem value="dollar">$</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid grid-cols-3 gap-2 items-end">
+                <div className="space-y-2">
+                  <Label htmlFor="pmiInsurance" className="text-sm">
+                    PMI Insurance
+                  </Label>
+                  <Input
+                    id="pmiInsurance"
+                    type="number"
+                    value={pmiInsurance}
+                    onChange={(e) => setPmiInsurance(Number(e.target.value))}
+                  />
+                </div>
+                <Select
+                  value={pmiInsuranceType}
+                  onValueChange={(value: 'percent' | 'dollar') => setPmiInsuranceType(value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="percent">%</SelectItem>
+                    <SelectItem value="dollar">$</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid grid-cols-3 gap-2 items-end">
+                <div className="space-y-2">
+                  <Label htmlFor="hoaFee" className="text-sm">
+                    HOA Fee
+                  </Label>
+                  <Input
+                    id="hoaFee"
+                    type="number"
+                    value={hoaFee}
+                    onChange={(e) => setHoaFee(Number(e.target.value))}
+                  />
+                </div>
+                <Select value={hoaFeeType} onValueChange={(value: 'percent' | 'dollar') => setHoaFeeType(value)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="percent">%</SelectItem>
+                    <SelectItem value="dollar">$</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid grid-cols-3 gap-2 items-end">
+                <div className="space-y-2">
+                  <Label htmlFor="otherCosts" className="text-sm">
+                    Other Costs
+                  </Label>
+                  <Input
+                    id="otherCosts"
+                    type="number"
+                    value={otherCosts}
+                    onChange={(e) => setOtherCosts(Number(e.target.value))}
+                  />
+                </div>
+                <Select
+                  value={otherCostsType}
+                  onValueChange={(value: 'percent' | 'dollar') => setOtherCostsType(value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="percent">%</SelectItem>
+                    <SelectItem value="dollar">$</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )}
+
+          <Button onClick={handleCalculate} disabled={loading} className="w-full">
+            {loading ? 'Calculating...' : 'Calculate'}
+          </Button>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {result && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Monthly Payment Breakdown</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  <div className="flex justify-between items-center p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
+                    <span className="font-semibold">Total Monthly Payment:</span>
+                    <span className="text-2xl font-bold text-green-600 dark:text-green-400">
+                      {formatCurrency(result.monthlyBreakdown.totalMonthlyPayment)}
+                    </span>
+                  </div>
+
+                  <div className="space-y-2 text-sm">
+                    <div className="flex justify-between">
+                      <span>Mortgage Payment (P&I):</span>
+                      <span className="font-medium">
+                        {formatCurrency(result.monthlyBreakdown.principalAndInterest)}
+                      </span>
+                    </div>
+
+                    {includeTaxesAndCosts && (
+                      <>
+                        {result.monthlyBreakdown.propertyTax > 0 && (
+                          <div className="flex justify-between">
+                            <span>Property Tax:</span>
+                            <span className="font-medium">
+                              {formatCurrency(result.monthlyBreakdown.propertyTax)}
+                            </span>
+                          </div>
+                        )}
+                        {result.monthlyBreakdown.homeInsurance > 0 && (
+                          <div className="flex justify-between">
+                            <span>Home Insurance:</span>
+                            <span className="font-medium">
+                              {formatCurrency(result.monthlyBreakdown.homeInsurance)}
+                            </span>
+                          </div>
+                        )}
+                        {result.monthlyBreakdown.pmiInsurance > 0 && (
+                          <div className="flex justify-between">
+                            <span>PMI Insurance:</span>
+                            <span className="font-medium">
+                              {formatCurrency(result.monthlyBreakdown.pmiInsurance)}
+                            </span>
+                          </div>
+                        )}
+                        {result.monthlyBreakdown.hoaFee > 0 && (
+                          <div className="flex justify-between">
+                            <span>HOA Fee:</span>
+                            <span className="font-medium">
+                              {formatCurrency(result.monthlyBreakdown.hoaFee)}
+                            </span>
+                          </div>
+                        )}
+                        {result.monthlyBreakdown.otherCosts > 0 && (
+                          <div className="flex justify-between">
+                            <span>Other Costs:</span>
+                            <span className="font-medium">
+                              {formatCurrency(result.monthlyBreakdown.otherCosts)}
+                            </span>
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </div>
+
+                  <Separator />
+
+                  <div className="text-xs text-gray-600 dark:text-gray-400 space-y-1">
+                    <div className="flex justify-between">
+                      <span>Loan Amount:</span>
+                      <span>{formatCurrency(result.loanAmount)}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>Total Interest:</span>
+                      <span>{formatCurrency(result.totalInterest)}</span>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/lib/app-definitions.ts
+++ b/lib/app-definitions.ts
@@ -84,10 +84,10 @@ export const appDefinitions: AppDefinition[] = [
   {
     id: "mortgage-calculator",
     title: "Mortgage Calculator",
-    defaultWidth: 500,
-    defaultHeight: 450,
+    defaultWidth: 600,
+    defaultHeight: 700,
     category: 'financial',
-    description: "Calculate monthly mortgage payments",
+    description: "Calculate monthly mortgage payments with taxes and costs",
     canBeDesktop: false,
   },
 


### PR DESCRIPTION
## Summary
- add a mortgage calculator API route that handles principal, interest, and optional taxes and fees
- build a client mortgage calculator experience with detailed monthly breakdowns and validation feedback
- register the calculator in the financial menu while keeping it off the desktop surface

## Testing
- pnpm lint *(fails: prompts for ESLint configuration)*
- pnpm dev --hostname 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_b_68dd82a60a448326935b0389c7793e6d