### PR TITLE
Add notes column to payment sources table

### DIFF
--- a/database/credits-schema.sql
+++ b/database/credits-schema.sql
@@ -266,6 +266,7 @@ CREATE TABLE IF NOT EXISTS sources (
     user_id uuid NULL,
     current_balance numeric(10, 2) NULL DEFAULT 0,
     max_balance numeric(10, 2) NULL DEFAULT 0,
+    notes text NULL,
     CONSTRAINT sources_pkey PRIMARY KEY (id),
     CONSTRAINT sources_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users (id),
     CONSTRAINT sources_type_check CHECK (((type = ANY (ARRAY['credit'::text, 'debit'::text]))))


### PR DESCRIPTION
Add `notes` column to the `sources` table to fix the 'notes' column not found error during payment source updates.

This resolves a bug where the `PaymentSourceEditor.tsx` component attempted to save a `notes` field that was missing from the database schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-4febddc6-b461-45ae-b3e1-b386f13e1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4febddc6-b461-45ae-b3e1-b386f13e1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

