### PR TITLE
Fix fetchSources to query sources table

### DIFF
--- a/lib/chart-data/fetchers.ts
+++ b/lib/chart-data/fetchers.ts
@@ -108,13 +108,12 @@ export async function fetchSources(userId: string): Promise<PaymentSourceData[]>
     }
 
     const { data, error } = await supabase
-      .from('payment_sources')
+      .from('sources')
       .select(`
         name,
-        balance,
+        current_balance,
         type,
-        max_balance,
-        transactions(count)
+        max_balance
       `)
       .eq('user_id', userId)
 
@@ -129,8 +128,8 @@ export async function fetchSources(userId: string): Promise<PaymentSourceData[]>
 
     const sourceData: PaymentSourceData[] = data.map((source: any) => ({
       source: source.name,
-      balance: source.balance ?? 0,
-      transactions: source.transactions?.[0]?.count ?? 0,
+      balance: source.current_balance ?? 0,
+      transactions: 0,
       max_balance: source.max_balance ?? undefined,
       type: source.type ?? undefined,
     }))


### PR DESCRIPTION
## Summary
- restore the fetchSources Supabase query to read from the existing sources table
- map current_balance to the payment source balance and remove the invalid transactions relation

## Testing
- pnpm lint *(fails: command prompts for ESLint configuration and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_68e3cf7bbd1c8326b5d579e94450580b